### PR TITLE
Fix: uuid.get for latest x-ui version

### DIFF
--- a/main.py
+++ b/main.py
@@ -173,7 +173,7 @@ def get_x_inbounds_with_uuid(session):
                             total = client["total"]
                             protocol = inbound.get("protocol")
                             expiry_time = milliseconds_to_seconds(client["expiryTime"])
-                            uuid_result = uuid["id"]
+                            uuid_result = uuid.get("id") or uuid.get("uuid") or uuid.get("uid")
                             # Check if used_traffic is greater than total
                             if used_traffic <= total and total > 0:
                                 last_value = total - (used_traffic)


### PR DESCRIPTION
Fix of this error :
```
Traceback (most recent call last):
  File "/root/X-Ui-to-Marzban/main.py", line 425, in <module>
    user_data = get_x_inbounds_with_uuid(X_SESSION)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/X-Ui-to-Marzban/main.py", line 176, in get_x_inbounds_with_uuid
    uuid_result = uuid["id"]
                  ~~~~^^^^^^
KeyError: 'id'
```